### PR TITLE
chore: rename project to HubHelper

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # Node.js Compatibility
 
-This document outlines the Node.js version compatibility for GitHub Security Analysis Tools.
+This document outlines the Node.js version compatibility for HubHelper.
 
 ## Supported Versions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to GitHub Security Analysis Tools
+# Contributing to HubHelper
 
 Thank you for your interest in contributing! This document provides guidelines and instructions for contributing to this project.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# GitHub Security Analysis Tools
+# HubHelper
 
 [![CI](https://github.com/sdh100shaun/gh-tools/workflows/CI/badge.svg)](https://github.com/sdh100shaun/gh-tools/actions/workflows/ci.yml)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org)
-[![npm version](https://img.shields.io/npm/v/@sdh100shaun/gh-security-tools)](https://www.npmjs.com/package/@sdh100shaun/gh-security-tools)
+[![npm version](https://img.shields.io/npm/v/@sdh100shaun/hubhelper)](https://www.npmjs.com/package/@sdh100shaun/hubhelper)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 AI-powered tools to visualize GitHub activity and flag security issues across organizations using the GitHub Copilot SDK.
@@ -43,7 +43,7 @@ AI-powered tools to visualize GitHub activity and flag security issues across or
 No installation required! Run directly with npx:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org <your-org> --token <your-token>
+npx @sdh100shaun/hubhelper analyze --org <your-org> --token <your-token>
 ```
 
 ### Global Installation
@@ -51,8 +51,8 @@ npx @sdh100shaun/gh-security-tools analyze --org <your-org> --token <your-token>
 Install globally to use as a CLI tool:
 
 ```bash
-npm install -g @sdh100shaun/gh-security-tools
-gh-security analyze --org <your-org>
+npm install -g @sdh100shaun/hubhelper
+hubhelper analyze --org <your-org>
 ```
 
 ### Local Development
@@ -96,13 +96,13 @@ Your GitHub personal access token needs the following scopes:
 Analyze all repositories and pull requests in an organization:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --token ghp_xxx
+npx @sdh100shaun/hubhelper analyze --org myorg --token ghp_xxx
 ```
 
 With custom options:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --days 60 --html report.html
+npx @sdh100shaun/hubhelper analyze --org myorg --days 60 --html report.html
 ```
 
 ### Using Global Installation
@@ -110,7 +110,7 @@ npx @sdh100shaun/gh-security-tools analyze --org myorg --days 60 --html report.h
 If installed globally:
 
 ```bash
-gh-security analyze --org myorg --days 60
+hubhelper analyze --org myorg --days 60
 ```
 
 ### Using Local Development
@@ -126,19 +126,19 @@ npm run dev analyze --org myorg --days 60
 Save results as JSON:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --json results.json
+npx @sdh100shaun/hubhelper analyze --org myorg --json results.json
 ```
 
 Save as HTML report:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --html report.html
+npx @sdh100shaun/hubhelper analyze --org myorg --html report.html
 ```
 
 Both formats:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --json results.json --html report.html
+npx @sdh100shaun/hubhelper analyze --org myorg --json results.json --html report.html
 ```
 
 ### Disable AI Insights
@@ -146,7 +146,7 @@ npx @sdh100shaun/gh-security-tools analyze --org myorg --json results.json --htm
 Run analysis without AI-powered recommendations:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --no-ai
+npx @sdh100shaun/hubhelper analyze --org myorg --no-ai
 ```
 
 ### Environment Variables
@@ -156,7 +156,7 @@ Instead of passing flags, you can use environment variables:
 ```bash
 export GITHUB_TOKEN=ghp_xxx
 export GITHUB_ORG=myorg
-npx @sdh100shaun/gh-security-tools analyze
+npx @sdh100shaun/hubhelper analyze
 ```
 
 ## Command Reference
@@ -255,7 +255,7 @@ This package is automatically published to npm via GitHub Actions when a new rel
 
 1. Create a new release on GitHub
 2. The `npm-publish.yml` workflow automatically builds and publishes
-3. Package is available via `npx @sdh100shaun/gh-security-tools`
+3. Package is available via `npx @sdh100shaun/hubhelper`
 
 ### Manual Publishing
 

--- a/SECURITY_FIX_PLAN.md
+++ b/SECURITY_FIX_PLAN.md
@@ -222,9 +222,9 @@ User-provided file paths are not validated, allowing writes outside intended dir
 
 **Attack Vectors:**
 ```bash
-npx gh-security-tools analyze --html ../../../etc/passwd
-npx gh-security-tools analyze --json ../../.ssh/authorized_keys
-npx gh-security-tools analyze --html /etc/cron.d/backdoor
+npx hubhelper analyze --html ../../../etc/passwd
+npx hubhelper analyze --json ../../.ssh/authorized_keys
+npx hubhelper analyze --html /etc/cron.d/backdoor
 ```
 
 ### Implementation Plan
@@ -415,13 +415,13 @@ Organization name and days parameters are not validated, allowing malicious inpu
 **Attack Vectors:**
 ```bash
 # SQL injection style (won't work but shows lack of validation)
-npx gh-security-tools --org "'; DROP TABLE--"
+npx hubhelper --org "'; DROP TABLE--"
 
 # DoS via excessive API calls
-npx gh-security-tools --org test --days 999999999
+npx hubhelper --org test --days 999999999
 
 # Invalid organization names
-npx gh-security-tools --org "../../../etc"
+npx hubhelper --org "../../../etc"
 ```
 
 ### Implementation Plan
@@ -739,15 +739,15 @@ gh repo create "test<script>alert(1)</script>" --private
 # Create PR with title: Fix bug</title><script>alert(document.cookie)</script>
 
 # Generate report and inspect HTML
-npx gh-security-tools analyze --org test --html report.html
+npx hubhelper analyze --org test --html report.html
 # Open report.html and check for unescaped content
 ```
 
 #### Path Traversal Testing
 ```bash
 # Attempt directory traversal
-npx gh-security-tools analyze --org test --html ../../../tmp/test.html
-npx gh-security-tools analyze --org test --json /etc/passwd.json
+npx hubhelper analyze --org test --html ../../../tmp/test.html
+npx hubhelper analyze --org test --json /etc/passwd.json
 
 # Verify error messages
 ```
@@ -755,12 +755,12 @@ npx gh-security-tools analyze --org test --json /etc/passwd.json
 #### Input Validation Testing
 ```bash
 # Test invalid org names
-npx gh-security-tools analyze --org "../etc" --days 30
-npx gh-security-tools analyze --org "'; DROP TABLE--" --days 30
+npx hubhelper analyze --org "../etc" --days 30
+npx hubhelper analyze --org "'; DROP TABLE--" --days 30
 
 # Test invalid days
-npx gh-security-tools analyze --org test --days -1
-npx gh-security-tools analyze --org test --days 999999
+npx hubhelper analyze --org test --days -1
+npx hubhelper analyze --org test --days 999999
 ```
 
 ---

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,6 +1,6 @@
 # Security Self-Review
 
-**Project:** GitHub Security Analysis Tools
+**Project:** HubHelper
 **Review Date:** 2026-01-23
 **Reviewer:** Automated Security Analysis
 **Scope:** Complete codebase security audit
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-This security review identifies potential vulnerabilities and security best practices in the GitHub Security Analysis Tools project. The review covers token management, input validation, XSS prevention, dependency security, and GitHub Actions workflow security.
+This security review identifies potential vulnerabilities and security best practices in the HubHelper project. The review covers token management, input validation, XSS prevention, dependency security, and GitHub Actions workflow security.
 
 **Overall Risk Level:** 🟡 **MEDIUM** (3 High, 5 Medium, 4 Low priority issues found)
 
@@ -95,8 +95,8 @@ if (options.html) {
 
 **Attack Vector:**
 ```bash
-npx gh-security-tools analyze --org test --html ../../../tmp/malicious.html
-npx gh-security-tools analyze --org test --json ../../etc/passwd
+npx hubhelper analyze --org test --html ../../../tmp/malicious.html
+npx hubhelper analyze --org test --json ../../etc/passwd
 ```
 
 **Impact:**
@@ -149,10 +149,10 @@ const days = parseInt(options.days);  // ❌ Can be NaN, negative, or excessivel
 **Attack Vector:**
 ```bash
 # Invalid organization name
-npx gh-security-tools analyze --org "../../../etc" --days -999999
+npx hubhelper analyze --org "../../../etc" --days -999999
 
 # Denial of service via excessive days
-npx gh-security-tools analyze --org test --days 999999999
+npx hubhelper analyze --org test --days 999999999
 ```
 
 **Impact:**
@@ -504,11 +504,11 @@ updates:
 gh repo create test-xss-<script>alert(1)</script>
 
 # 2. Path Traversal Testing
-npx gh-security-tools analyze --org test --html ../../../tmp/test.html
+npx hubhelper analyze --org test --html ../../../tmp/test.html
 
 # 3. Input Validation Testing
-npx gh-security-tools analyze --org "'; DROP TABLE repos;--" --days -1
-npx gh-security-tools analyze --org test --days 999999999
+npx hubhelper analyze --org "'; DROP TABLE repos;--" --days -1
+npx hubhelper analyze --org test --days 999999999
 
 # 4. Rate Limit Testing
 # Run analysis on large org repeatedly

--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -10,7 +10,7 @@
                    img-src 'self' data: https:;
                    font-src 'self';
                    connect-src 'self';">
-    <title>{% if title %}{{ title }} - {% endif %}GitHub Security Tools Documentation</title>
+    <title>{% if title %}{{ title }} - {% endif %}HubHelper Documentation</title>
     <meta name="description" content="{{ description or 'AI-powered tools to visualize GitHub activity and flag security issues across organizations' }}">
 
     <!-- Favicon -->
@@ -20,13 +20,13 @@
     <link rel="stylesheet" href="{{ '/css/main.css' | url }}">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="{{ title or 'GitHub Security Tools' }}">
+    <meta property="og:title" content="{{ title or 'HubHelper' }}">
     <meta property="og:description" content="{{ description or 'AI-powered tools to visualize GitHub activity and flag security issues' }}">
     <meta property="og:type" content="website">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="{{ title or 'GitHub Security Tools' }}">
+    <meta name="twitter:title" content="{{ title or 'HubHelper' }}">
     <meta name="twitter:description" content="{{ description or 'AI-powered security analysis for GitHub organizations' }}">
 </head>
 <body>
@@ -38,7 +38,7 @@
                 <div class="nav-brand">
                     <a href="{{ '/' | url }}" class="brand-link">
                         <span class="brand-icon">🔐</span>
-                        <span class="brand-text">GitHub Security Tools</span>
+                        <span class="brand-text">HubHelper</span>
                     </a>
                 </div>
 
@@ -71,7 +71,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>GitHub Security Tools</h3>
+                    <h3>HubHelper</h3>
                     <p>AI-powered security analysis for GitHub organizations</p>
                 </div>
 
@@ -96,14 +96,14 @@
                 <div class="footer-section">
                     <h4>Resources</h4>
                     <ul>
-                        <li><a href="https://www.npmjs.com/package/@sdh100shaun/gh-security-tools" target="_blank" rel="noopener">npm Package</a></li>
+                        <li><a href="https://www.npmjs.com/package/@sdh100shaun/hubhelper" target="_blank" rel="noopener">npm Package</a></li>
                         <li><a href="https://github.com/github/copilot-sdk" target="_blank" rel="noopener">GitHub Copilot SDK</a></li>
                     </ul>
                 </div>
             </div>
 
             <div class="footer-bottom">
-                <p>&copy; {% year %} GitHub Security Tools. Licensed under MIT.</p>
+                <p>&copy; {% year %} HubHelper. Licensed under MIT.</p>
                 <p>Built with <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a></p>
             </div>
         </div>

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,5 +1,5 @@
 /**
- * Main JavaScript for GitHub Security Tools Documentation
+ * Main JavaScript for HubHelper Documentation
  */
 
 // Mobile Navigation Toggle
@@ -137,4 +137,4 @@
   }
 })();
 
-console.log('GitHub Security Tools Documentation - Ready');
+console.log('HubHelper Documentation - Ready');

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -9,7 +9,7 @@ description: AI-powered tools to visualize GitHub activity and flag security iss
         <div class="hero-content">
             <h1 class="hero-title">
                 <span class="hero-icon">🔐</span>
-                GitHub Security Analysis Tools
+                HubHelper
             </h1>
             <p class="hero-description">
                 AI-powered tools to visualize GitHub activity and flag security issues across organizations using the GitHub Copilot SDK.
@@ -24,7 +24,7 @@ description: AI-powered tools to visualize GitHub activity and flag security iss
                 </a>
             </div>
             <div class="hero-install">
-                <code class="install-command">npx @sdh100shaun/gh-security-tools analyze --org myorg</code>
+                <code class="install-command">npx @sdh100shaun/hubhelper analyze --org myorg</code>
             </div>
         </div>
     </div>
@@ -119,7 +119,7 @@ description: AI-powered tools to visualize GitHub activity and flag security iss
             <div class="quick-start-step">
                 <h3><span class="step-number">2</span> Run Analysis</h3>
                 <p>Use npx to run the tool without installation:</p>
-                <pre><code class="language-bash">npx @sdh100shaun/gh-security-tools analyze \
+                <pre><code class="language-bash">npx @sdh100shaun/hubhelper analyze \
   --org your-org-name \
   --token your-github-token</code></pre>
             </div>
@@ -127,7 +127,7 @@ description: AI-powered tools to visualize GitHub activity and flag security iss
             <div class="quick-start-step">
                 <h3><span class="step-number">3</span> Review Results</h3>
                 <p>View security issues in your terminal or export to JSON/HTML:</p>
-                <pre><code class="language-bash">npx @sdh100shaun/gh-security-tools analyze \
+                <pre><code class="language-bash">npx @sdh100shaun/hubhelper analyze \
   --org your-org \
   --html report.html</code></pre>
             </div>

--- a/docs/pages/api/index.md
+++ b/docs/pages/api/index.md
@@ -1,16 +1,16 @@
 ---
 layout: page.njk
 title: API Reference
-description: Complete command-line interface reference for GitHub Security Analysis Tools
+description: Complete command-line interface reference for HubHelper
 githubEdit: true
 ---
 
 ## Command Overview
 
-The `gh-security-tools` CLI provides commands for analyzing GitHub organization security:
+The `hubhelper` CLI provides commands for analyzing GitHub organization security:
 
 ```bash
-gh-security-tools <command> [options]
+hubhelper <command> [options]
 ```
 
 Available commands:
@@ -25,8 +25,8 @@ Analyze an entire GitHub organization for security issues.
 ### Synopsis
 
 ```bash
-gh-security-tools analyze [options]
-npx @sdh100shaun/gh-security-tools analyze [options]
+hubhelper analyze [options]
+npx @sdh100shaun/hubhelper analyze [options]
 ```
 
 ### Options
@@ -41,7 +41,7 @@ GitHub organization name to analyze.
 - **Example**: `--org my-company`
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org github
+npx @sdh100shaun/hubhelper analyze --org github
 ```
 
 #### `-t, --token <token>`
@@ -57,7 +57,7 @@ GitHub Personal Access Token for authentication.
 - **Example**: `--token ghp_xxxxxxxxxxxxxxxxxxxx`
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --token ghp_xxxxxxxxxxxxxxxxxxxx
 ```
@@ -75,7 +75,7 @@ Number of days to look back for pull request analysis.
 - **Example**: `--days 90`
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --days 60
+npx @sdh100shaun/hubhelper analyze --org myorg --days 60
 ```
 
 **Note**: Larger ranges may take longer to process and consume more API quota.
@@ -91,7 +91,7 @@ Save analysis results as JSON to the specified file.
 - **Example**: `--json results.json`
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --json reports/analysis-2026-01-24.json
 ```
@@ -113,7 +113,7 @@ Save analysis results as an HTML report to the specified file.
 - **Example**: `--html report.html`
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --html reports/security-report.html
 ```
@@ -135,7 +135,7 @@ Disable AI-powered insights and recommendations.
 - **Example**: `--no-ai`
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --no-ai
+npx @sdh100shaun/hubhelper analyze --org myorg --no-ai
 ```
 
 Use this flag when:
@@ -153,7 +153,7 @@ Analyze an organization using environment variables:
 export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 export GITHUB_ORG=myorg
 
-npx @sdh100shaun/gh-security-tools analyze
+npx @sdh100shaun/hubhelper analyze
 ```
 
 #### Full Analysis with All Options
@@ -161,7 +161,7 @@ npx @sdh100shaun/gh-security-tools analyze
 Comprehensive analysis with custom time range and both output formats:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org mycompany \
   --token ghp_xxxxxxxxxxxxxxxxxxxx \
   --days 90 \
@@ -174,7 +174,7 @@ npx @sdh100shaun/gh-security-tools analyze \
 Fast analysis of the last week:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --days 7 \
   --no-ai
@@ -185,7 +185,7 @@ npx @sdh100shaun/gh-security-tools analyze \
 Automated analysis in continuous integration:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org $ORG_NAME \
   --token $GITHUB_TOKEN \
   --days 30 \
@@ -254,7 +254,7 @@ Check a specific repository for security issues.
 ### Synopsis
 
 ```bash
-gh-security-tools check-repo <owner/repo> [options]
+hubhelper check-repo <owner/repo> [options]
 ```
 
 ### Planned Options
@@ -271,7 +271,7 @@ Monitor an organization in real-time for security issues.
 ### Synopsis
 
 ```bash
-gh-security-tools watch [options]
+hubhelper watch [options]
 ```
 
 ### Planned Options
@@ -404,7 +404,7 @@ import type {
   AnalysisResult,
   SecurityIssueType,
   SeverityLevel
-} from '@sdh100shaun/gh-security-tools';
+} from '@sdh100shaun/hubhelper';
 ```
 
 ## Next Steps

--- a/docs/pages/contributing/index.md
+++ b/docs/pages/contributing/index.md
@@ -1,13 +1,13 @@
 ---
 layout: page.njk
 title: Contributing
-description: Guide for contributing to GitHub Security Analysis Tools
+description: Guide for contributing to HubHelper
 githubEdit: true
 ---
 
 ## Welcome Contributors!
 
-Thank you for your interest in contributing to GitHub Security Analysis Tools! This document provides guidelines and instructions for contributing to the project.
+Thank you for your interest in contributing to HubHelper! This document provides guidelines and instructions for contributing to the project.
 
 ## Ways to Contribute
 

--- a/docs/pages/getting-started/index.md
+++ b/docs/pages/getting-started/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page.njk
 title: Getting Started
-description: Complete guide to installing and using GitHub Security Analysis Tools
+description: Complete guide to installing and using HubHelper
 githubEdit: true
 ---
 
@@ -22,7 +22,7 @@ Before you begin, ensure you have:
 No installation required! Use npx to run the tool directly:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org your-org --token your-token
+npx @sdh100shaun/hubhelper analyze --org your-org --token your-token
 ```
 
 This is the fastest way to get started and ensures you always use the latest version.
@@ -32,13 +32,13 @@ This is the fastest way to get started and ensures you always use the latest ver
 Install globally to use the tool from anywhere:
 
 ```bash
-npm install -g @sdh100shaun/gh-security-tools
+npm install -g @sdh100shaun/hubhelper
 ```
 
 Then run with:
 
 ```bash
-gh-security analyze --org your-org
+hubhelper analyze --org your-org
 ```
 
 ### Option 3: Local Development
@@ -83,7 +83,7 @@ GITHUB_ORG=your-organization-name
 Then run without flags:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze
+npx @sdh100shaun/hubhelper analyze
 ```
 
 ### Using Command-Line Flags
@@ -91,7 +91,7 @@ npx @sdh100shaun/gh-security-tools analyze
 Pass configuration via command-line options:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org your-org \
   --token ghp_xxxxxxxxxxxxxxxxxxxx \
   --days 30
@@ -104,7 +104,7 @@ npx @sdh100shaun/gh-security-tools analyze \
 Run a basic security analysis:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg
+npx @sdh100shaun/hubhelper analyze --org myorg
 ```
 
 This will:
@@ -118,7 +118,7 @@ This will:
 Look back a specific number of days (1-365):
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --days 90
+npx @sdh100shaun/hubhelper analyze --org myorg --days 90
 ```
 
 ### Export Results
@@ -126,19 +126,19 @@ npx @sdh100shaun/gh-security-tools analyze --org myorg --days 90
 Save results in JSON format for automation:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --json report.json
+npx @sdh100shaun/hubhelper analyze --org myorg --json report.json
 ```
 
 Save results as an HTML report:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --html report.html
+npx @sdh100shaun/hubhelper analyze --org myorg --html report.html
 ```
 
 Save both formats:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --json results.json \
   --html report.html
@@ -149,7 +149,7 @@ npx @sdh100shaun/gh-security-tools analyze \
 Run analysis without AI-powered recommendations:
 
 ```bash
-npx @sdh100shaun/gh-security-tools analyze --org myorg --no-ai
+npx @sdh100shaun/hubhelper analyze --org myorg --no-ai
 ```
 
 ## Understanding the Output
@@ -193,7 +193,7 @@ Add to your weekly routine:
 
 ```bash
 # Check the last 7 days
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --days 7 \
   --html weekly-report.html
@@ -205,7 +205,7 @@ Before a major release:
 
 ```bash
 # Comprehensive 90-day analysis
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --days 90 \
   --json audit-$(date +%Y-%m-%d).json
@@ -218,7 +218,7 @@ Add to your CI pipeline (e.g., GitHub Actions):
 ```yaml
 - name: Run Security Analysis
   run: |
-    npx @sdh100shaun/gh-security-tools analyze \
+    npx @sdh100shaun/hubhelper analyze \
       --org ${ github.repository_owner } \
       --token ${ secrets.GITHUB_TOKEN } \
       --json security-report.json

--- a/docs/pages/security/index.md
+++ b/docs/pages/security/index.md
@@ -1,13 +1,13 @@
 ---
 layout: page.njk
 title: Security
-description: Security features, best practices, and vulnerability reporting for GitHub Security Analysis Tools
+description: Security features, best practices, and vulnerability reporting for HubHelper
 githubEdit: true
 ---
 
 ## Security Overview
 
-GitHub Security Analysis Tools is designed with security as a top priority. This page outlines our security features, implemented protections, and best practices for using the tool safely.
+HubHelper is designed with security as a top priority. This page outlines our security features, implemented protections, and best practices for using the tool safely.
 
 ## Implemented Security Features
 
@@ -201,10 +201,10 @@ npm test
 ```bash
 # ✅ Good: Use environment variables
 export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
-npx @sdh100shaun/gh-security-tools analyze --org myorg
+npx @sdh100shaun/hubhelper analyze --org myorg
 
 # ❌ Bad: Token in command (visible in shell history)
-npx @sdh100shaun/gh-security-tools analyze --token ghp_xxx --org myorg
+npx @sdh100shaun/hubhelper analyze --token ghp_xxx --org myorg
 ```
 
 ### 2. Secure Output Files
@@ -217,7 +217,7 @@ npx @sdh100shaun/gh-security-tools analyze --token ghp_xxx --org myorg
 
 ```bash
 # ✅ Good: Save to secure directory
-npx @sdh100shaun/gh-security-tools analyze \
+npx @sdh100shaun/hubhelper analyze \
   --org myorg \
   --html secure/reports/output.html
 
@@ -234,10 +234,10 @@ echo "secure/" >> .gitignore
 
 ```bash
 # ✅ Good: Analyze last 7 days for weekly check
-npx @sdh100shaun/gh-security-tools analyze --org myorg --days 7
+npx @sdh100shaun/hubhelper analyze --org myorg --days 7
 
 # ⚠️ Caution: 365-day analysis uses more API quota
-npx @sdh100shaun/gh-security-tools analyze --org myorg --days 365
+npx @sdh100shaun/hubhelper analyze --org myorg --days 365
 ```
 
 ### 4. CI/CD Integration Security
@@ -250,7 +250,7 @@ When using in automated pipelines:
   env:
     GITHUB_TOKEN: ${% raw %}{{ {% endraw %}secrets.ANALYSIS_TOKEN {% raw %}}}{% endraw %}
   run: |
-    npx @sdh100shaun/gh-security-tools analyze \
+    npx @sdh100shaun/hubhelper analyze \
       --org ${% raw %}{{ {% endraw %}github.repository_owner {% raw %}}}{% endraw %} \
       --json security-report.json \
       --no-ai
@@ -258,7 +258,7 @@ When using in automated pipelines:
 # ❌ Bad: Don't use GITHUB_TOKEN directly (too broad permissions)
 - name: Bad Example
   run: |
-    npx @sdh100shaun/gh-security-tools analyze \
+    npx @sdh100shaun/hubhelper analyze \
       --token ${% raw %}{{ {% endraw %}secrets.GITHUB_TOKEN {% raw %}}}{% endraw %}  # Don't do this!
 ```
 

--- a/examples/basic-usage.ts
+++ b/examples/basic-usage.ts
@@ -1,7 +1,7 @@
 /**
- * Example: Basic Usage of GitHub Security Analysis Tools
+ * Example: Basic Usage of HubHelper
  *
- * This example demonstrates how to use the analysis tools programmatically
+ * This example demonstrates how to use HubHelper programmatically
  * rather than through the CLI.
  */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@sdh100shaun/gh-security-tools",
+  "name": "@sdh100shaun/hubhelper",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sdh100shaun/gh-security-tools",
+      "name": "@sdh100shaun/hubhelper",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -17,8 +17,7 @@
         "ora": "^8.0.1"
       },
       "bin": {
-        "gh-security": "dist/index.js",
-        "gh-security-tools": "dist/index.js"
+        "hubhelper": "dist/index.js"
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "@sdh100shaun/gh-security-tools",
+  "name": "@sdh100shaun/hubhelper",
   "version": "1.0.0",
   "description": "AI-powered tools to visualize GitHub activity and flag security issues across organizations",
   "main": "dist/index.js",
   "type": "module",
   "bin": {
-    "gh-security": "dist/index.js",
-    "gh-security-tools": "dist/index.js"
+    "hubhelper": "dist/index.js"
   },
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {


### PR DESCRIPTION
- Update package.json name from @sdh100shaun/gh-security-tools to @sdh100shaun/hubhelper
- Change CLI bin command from gh-security/gh-security-tools to hubhelper
- Update all documentation files with new project name
- Update README, CONTRIBUTING, COMPATIBILITY docs
- Update security documentation (SECURITY_REVIEW.md, SECURITY_FIX_PLAN.md)
- Update example files and JS assets